### PR TITLE
Correctly parse fixnums between -129 and -256.

### DIFF
--- a/lib/marshal.js
+++ b/lib/marshal.js
@@ -83,7 +83,11 @@ Marshal = (function () {
     }
     else if (small === -1) {
       var large = this.buffer.readInt8(this._index++);
-      return large;
+      if (large >= 0 && large <= 127) {
+        return large - 256;
+      } else {
+        return large;
+      }
     }
     else if (small === -2) {
       var large = this.buffer.readInt16LE(this._index);

--- a/test/marshal.js
+++ b/test/marshal.js
@@ -15,7 +15,9 @@ var intySixFiveFiveThreeSix = new Buffer('04086903000001', 'hex');
 var intyTwoPowerThirtyMinusOne = new Buffer('04086904ffffff3f', 'hex');
 var intyNegOne = new Buffer('040869fa', 'hex');
 var intyNegOneTwoFour = new Buffer('040869ff84', 'hex');
+var intyNegOneTwoNine = new Buffer('040869ff7f', 'hex');
 var intyNegTwoFiveSeven = new Buffer('040869fefffe', 'hex');
+var intyNegTwoFiveSix = new Buffer('040869ff00', 'hex');
 var intyNegSixFiveFiveThreeSeven = new Buffer('040869fdfffffe', 'hex');
 var intyNegTwoPowerThirty = new Buffer('040869fc000000c0', 'hex');
 var symbolyHello = new Buffer('04083a0a68656c6c6f', 'hex');
@@ -90,6 +92,14 @@ test('marshal', function (t) {
       });
       t.test('-124', function (t) {
         t.equals(m.load(intyNegOneTwoFour).parsed, -124, 'should equal -124');
+        t.end();
+      });
+      t.test('-129', function (t) {
+        t.equals(m.load(intyNegOneTwoNine).parsed, -129, 'should equal -129');
+        t.end();
+      });
+      t.test('-256', function (t) {
+        t.equals(m.load(intyNegTwoFiveSix).parsed, -256, 'should equal -256');
         t.end();
       });
       t.test('-257', function (t) {


### PR DESCRIPTION
Fixes https://github.com/instore/node-marshal/issues/2.
