### PR TITLE
Bug Fix

### DIFF
--- a/lib/marshal.js
+++ b/lib/marshal.js
@@ -198,8 +198,14 @@ Marshal = (function () {
     // \x04\bo:\vObject\a:\t@fooI\"\bbar\x06:\x06ET:\t@barI\"\bbaz\x06;\aT
 
     // symbol name
-    this._index++;
-    var name = this._parseSymbol();
+    
+    var name = "";
+    switch(this._buffer.readInt8(this._index++)) {
+      case 0x3A:     
+         name = this._parseSymbol(); break;
+      case 0x3B:
+         name = this._parseSymbolLink(); break;
+    }
 
     // hash
     var object = this._parseHash();

--- a/lib/marshal.js
+++ b/lib/marshal.js
@@ -200,7 +200,7 @@ Marshal = (function () {
     // symbol name
     
     var name = "";
-    switch(this._buffer.readInt8(this._index++)) {
+    switch(this.buffer.readInt8(this._index++)) {
       case 0x3A:     
          name = this._parseSymbol(); break;
       case 0x3B:

--- a/lib/marshal.js
+++ b/lib/marshal.js
@@ -199,13 +199,7 @@ Marshal = (function () {
 
     // symbol name
     
-    var name = "";
-    switch(this.buffer.readInt8(this._index++)) {
-      case 0x3A:     
-         name = this._parseSymbol(); break;
-      case 0x3B:
-         name = this._parseSymbolLink(); break;
-    }
+    var name = this._parse();
 
     // hash
     var object = this._parseHash();


### PR DESCRIPTION
Fix the Bug When Object class name is a symbol link, in some cases (symbol table length > 32), it can't work properly.