### PR TITLE
Break: Upgrade code to ES6+, require `node@>=8`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,7 @@
 language: node_js
 node_js:
-  - '6'
-  - '7'
-  - '8'
-  - '9'
-  - '10'
+  - node
+  - 10
+  - 8
 after_script:
   - npm run coverage && npm run codecov

--- a/index.js
+++ b/index.js
@@ -1,1 +1,1 @@
-module.exports = require('./lib/marshal');
+module.exports = require('./lib/marshal')

--- a/lib/debug.js
+++ b/lib/debug.js
@@ -1,0 +1,4 @@
+const debug = require('debug')('marshal')
+const IS_DEBUG = debug.enabled
+
+module.exports = { debug, IS_DEBUG }

--- a/lib/ivar.js
+++ b/lib/ivar.js
@@ -1,23 +1,16 @@
-var Ivar
-
-Ivar = (function() {
-  function Ivar(rawString, encoding) {
+class Ivar {
+  constructor (rawString, encoding) {
     this.buffer = Buffer.from(rawString)
-    this.encoding = encoding
-    this.string = this.buffer.toString('utf8')
+    this.encoding = encoding || 'utf8'
 
-    return this
+    // this.string = this.buffer.toString('utf8') // TODO: NOTE: seems this is not used later
   }
 
-  Ivar.prototype.toString = function() {
-    return this.buffer.toString(this.encoding || 'utf8')
+  toString () {
+    return this.buffer.toString(this.encoding)
   }
+}
 
-  Ivar.prototype.toJSON = function() {
-    return this.toString()
-  }
-
-  return Ivar
-})()
+Ivar.prototype.toJSON = Ivar.prototype.toString
 
 module.exports = Ivar

--- a/lib/ivar.js
+++ b/lib/ivar.js
@@ -1,23 +1,23 @@
-var Ivar;
+var Ivar
 
-Ivar = (function () {
+Ivar = (function() {
   function Ivar(rawString, encoding) {
-    this.buffer = Buffer.from(rawString);
-    this.encoding = encoding;
-    this.string = this.buffer.toString('utf8');
+    this.buffer = Buffer.from(rawString)
+    this.encoding = encoding
+    this.string = this.buffer.toString('utf8')
 
-    return this;
-  };
+    return this
+  }
 
-  Ivar.prototype.toString = function () {
-    return this.buffer.toString(this.encoding || 'utf8');
-  };
+  Ivar.prototype.toString = function() {
+    return this.buffer.toString(this.encoding || 'utf8')
+  }
 
-  Ivar.prototype.toJSON = function () {
-    return this.toString();
-  };
+  Ivar.prototype.toJSON = function() {
+    return this.toString()
+  }
 
-  return Ivar;
-})();
+  return Ivar
+})()
 
-module.exports = Ivar;
+module.exports = Ivar

--- a/lib/marshal.js
+++ b/lib/marshal.js
@@ -1,368 +1,366 @@
-var debug = require('debug')('marshal')
-var MarshalError = require('./marshalError')
-var Ivar = require('./ivar')
+const Ivar = require('./ivar')
+const MarshalError = require('./marshalError')
+const { debug, IS_DEBUG } = require('./debug')
 
-// Copied directly from https://github.com/MikeMcl/decimal.js/blob/fb37ca6bde56676d6d5a98df2bf8721e8fa81085/decimal.js#L27
-// Base conversion alphabet.
-var NUMERALS = '0123456789abcdef'
+const HEX_TO_DEC_MAP = { 0: 0, 1: 1, 2: 2, 3: 3, 4: 4, 5: 5, 6: 6, 7: 7, 8: 8, 9: 9, a: 10, b: 11, c: 12, d: 13, e: 14, f: 15 }
+// const HEX_TO_DEC_MAP = '0123456789abcdef'.split('').reduce((o, v, i) => {
+//   o[ v ] = i
+//   return o
+// }, {})
 
-var Marshal
-
-Marshal = (function() {
-  function Marshal(buffer, encoding) {
-    if (buffer !== void 0) this.load(buffer, encoding)
-
-    return this
+const _parseInt8 = (marshal) => {
+  const value = marshal.buffer.readInt8(marshal._index)
+  marshal._index += 1
+  return value
+}
+const _parseInt8LE = (marshal) => { // TODO: simpler value calc?
+  const value = -(
+    ~(
+      0xffffff00 + marshal.buffer.readUInt8(marshal._index)
+    ) + 1
+  )
+  marshal._index += 1
+  return value
+}
+const _parseInt16LE = (marshal) => {
+  const value = marshal.buffer.readInt16LE(marshal._index)
+  marshal._index += 2
+  return value
+}
+const _parseInt24LE = (marshal) => { // TODO: simpler value calc?
+  const value = -(
+    ~(
+      (
+        (0xffff0000 + marshal.buffer.readUInt16LE(marshal._index + 1)) << 8
+      ) + marshal.buffer.readUInt8(marshal._index)
+    ) + 1
+  )
+  marshal._index += 3
+  return value
+}
+const _parseInt32LE = (marshal) => {
+  const value = marshal.buffer.readInt32LE(marshal._index)
+  marshal._index += 4
+  return value
+}
+const _parseUInt8 = (marshal) => {
+  const value = marshal.buffer.readUInt8(marshal._index)
+  marshal._index += 1
+  return value
+}
+const _parseUInt16LE = (marshal) => {
+  const value = marshal.buffer.readUInt16LE(marshal._index)
+  marshal._index += 2
+  return value
+}
+const _parseUInt24LE = (marshal) => {
+  const value = Buffer.from( // TODO: less buffer/string convert?
+    marshal.buffer.toString('hex', marshal._index, marshal._index + 3) + '00',
+    'hex'
+  ).readUInt32LE(0)
+  marshal._index += 3
+  return value
+}
+const _parseUInt32LE = (marshal) => {
+  const value = marshal.buffer.readUInt32LE(marshal._index)
+  marshal._index += 4
+  return value
+}
+const _parseBuffer = (marshal, byteLength) => {
+  const buffer = marshal.buffer.slice(marshal._index, marshal._index + byteLength)
+  marshal._index += byteLength
+  return buffer
+}
+const _parseByteString = (marshal, byteLength) => {
+  let byteString = ''
+  let index = marshal._index
+  let indexMax = marshal._index + byteLength
+  for (; index < indexMax; index++) {
+    byteString = marshal.buffer.toString('hex', index, index + 1) + byteString
   }
+  marshal._index += byteLength
+  return byteString
+}
 
-  Marshal.prototype._parse = function() {
-    var typeCode = this.buffer.readUInt8(this._index++)
-    debug(
-      'type code ' +
-      '0x' +
-      this.buffer.toString('hex', this._index - 1, this._index) +
-      ' index ' +
-      (this._index - 1)
-    )
-    switch (typeCode) {
-      case 0x30: // 0 - nil
-        return null
-      case 0x54: // T - true
-        return true
-      case 0x46: // F - false
-        return false
-      case 0x69: // i - integer
-        return this._parseInteger()
-      case 0x22: // " - string
-        return this._parseString()
-      case 0x3a: // : - symbol
-        return this._parseSymbol()
-      case 0x3b: // ; - symbol symlink
-        return this._parseSymbolLink()
-      case 0x40: // @ - object link
-        return this._parseObjectLink()
-      case 0x49: // I - IVAR (encoded string or regexp)
-        return this._parseIvar()
-      case 0x5b: // [ - array
-        return this._parseArray()
-      case 0x6f: // o - object
-        return this._parseObject()
-      case 0x7b: // { - hash
-        return this._parseHash()
-      case 0x6c: // l - bignum
-        return this._parseBignum()
-      case 0x66: // f - float
-        return this._parseFloat()
-      case 0x2f: // / - regexp
-      case 0x63: // c - class
-      case 0x6d: // m - module
-      default:
-        throw new MarshalError('unsupported typecode ' + typeCode, this)
-    }
+const _parse = (marshal) => {
+  const typeCode = _parseUInt8(marshal)
+
+  IS_DEBUG && debug('type code 0x%s index %d',
+    marshal.buffer.toString('hex', marshal._index - 1, marshal._index),
+    marshal._index - 1
+  )
+
+  switch (typeCode) {
+    case 0x30: // 0 - nil
+      return null
+    case 0x54: // T - true
+      return true
+    case 0x46: // F - false
+      return false
+    case 0x69: // i - integer
+      return _parseInteger(marshal)
+    case 0x22: // " - string
+      return _parseString(marshal)
+    case 0x3a: // : - symbol
+      return _parseSymbol(marshal)
+    case 0x3b: // ; - symbol symlink
+      return _parseSymbolLink(marshal)
+    case 0x40: // @ - object link
+      return _parseObjectLink(marshal)
+    case 0x49: // I - IVAR (encoded string or regexp)
+      return _parseIvar(marshal)
+    case 0x5b: // [ - array
+      return _parseArray(marshal)
+    case 0x6f: // o - object
+      return _parseObject(marshal)
+    case 0x7b: // { - hash
+      return _parseHash(marshal)
+    case 0x6c: // l - bignum
+      return _parseBignum(marshal)
+    case 0x66: // f - float
+      return _parseFloat(marshal)
+    case 0x2f: // / - regexp
+    case 0x63: // c - class
+    case 0x6d: // m - module
+    default:
+      throw new MarshalError(`unsupported typecode ${typeCode}`, marshal)
   }
+}
 
-  Marshal.prototype._getLength = function() {
-    var length = this.buffer.readInt8(this._index++) // read the number of "machine words" - 16bit integers
-    if (length === 0) {
-      length = 0
-    } else if (length >= 6) {
-      length = length - 5
-    } else if (length <= -6) {
-      length = length + 5
+const _parseTypeLength = (marshal) => {
+  const length = marshal.buffer.readInt8(marshal._index) // read the number of "machine words" - 16bit integers
+  marshal._index += 1
+  return length >= 6 ? length - 5
+    : length <= -6 ? length + 5
+      : length
+}
+
+/** Parse a float.
+ * @return The decoded float.
+ */
+const _parseFloat = (marshal) => {
+  const floatString = _parseBuffer(marshal, _parseTypeLength(marshal)).toString('utf8') // TODO: use `ascii`
+  return floatString === 'inf' ? Infinity
+    : floatString === '-inf' ? -Infinity
+      : floatString === 'nan' ? NaN
+        : parseFloat(floatString)
+}
+
+/** Parse a bignum.
+ * @return The decoded bignum.
+ */
+const _parseBignum = (marshal) => {
+  const isNegative = _parseInt8(marshal) === 0x2d // read the sign byte and check for '-'
+  debug('isNegative: %s', isNegative)
+
+  // the word length appears to always be positive but still follows the Marshal length logic
+  const byteLength = _parseTypeLength(marshal) * 2
+  debug('byteLength: %s', byteLength)
+
+  // it appears that words are always zero padded - no odd number of bytes
+  const byteString = _parseByteString(marshal, byteLength)
+  debug('byteString: %j', byteString)
+
+  // Modified from https://github.com/MikeMcl/decimal.js/blob/fb37ca6bde56676d6d5a98df2bf8721e8fa81085/decimal.js#L2597
+  const base10Array = [ 0 ]
+  for (let i = 0; i < byteString.length; i++) {
+    for (let base10ArrayLength = base10Array.length; base10ArrayLength--;) {
+      base10Array[ base10ArrayLength ] *= 16
     }
-    return length
-  }
-
-  /** Parse a float.
-   * @return The decoded float.
-   */
-  Marshal.prototype._parseFloat = function() {
-    var length = this._getLength()
-    var floatValue = this.buffer.slice(this._index, this._index + length)
-    this._index = this._index + length
-    if (floatValue.toString('utf8') === 'inf') {
-      return Infinity
-    }
-    if (floatValue.toString('utf8') === '-inf') {
-      return -Infinity
-    }
-    if (floatValue.toString('utf8') === 'nan') {
-      return NaN
-    }
-    return parseFloat(floatValue.toString('utf8'))
-  }
-
-  /** Parse a bignum.
-   * @return The decoded bignum.
-   */
-  Marshal.prototype._parseBignum = function() {
-    var isNegative = this.buffer.readInt8(this._index++) === 0x2d // read the sign byte and check for '-'
-    debug('isNegative: %s', isNegative)
-
-    // the word length appears to always be positive but still follows the Marshal length logic
-    var wordLength = this._getLength()
-    debug('wordLength: %s', wordLength)
-
-    // it appears that words are always zero padded - no odd number of bytes
-    var byteLength = wordLength * 2
-    var byteString = ''
-    for (var i = 0; i < byteLength; i++, this._index++) {
-      byteString =
-        this.buffer.toString('hex', this._index, this._index + 1) + byteString
-    }
-    debug('byteString: %j', byteString)
-
-    // Modified from https://github.com/MikeMcl/decimal.js/blob/fb37ca6bde56676d6d5a98df2bf8721e8fa81085/decimal.js#L2597
-    var base10Array = [0]
-    var i, j, base10ArrayLength
-    for (i = 0; i < byteString.length; i++) {
-      for (base10ArrayLength = base10Array.length; base10ArrayLength--; )
-        base10Array[base10ArrayLength] *= 16
-      base10Array[0] += NUMERALS.indexOf(byteString.charAt(i))
-      for (j = 0; j < base10Array.length; j++) {
-        if (base10Array[j] > 10 - 1) {
-          if (base10Array[j + 1] === void 0) base10Array[j + 1] = 0
-          base10Array[j + 1] += (base10Array[j] / 10) | 0
-          base10Array[j] %= 10
-        }
+    base10Array[ 0 ] += HEX_TO_DEC_MAP[ byteString.charAt(i) ]
+    for (let j = 0; j < base10Array.length; j++) {
+      if (base10Array[ j ] > 10 - 1) {
+        if (base10Array[ j + 1 ] === undefined) base10Array[ j + 1 ] = 0
+        base10Array[ j + 1 ] += (base10Array[ j ] / 10) | 0
+        base10Array[ j ] %= 10
       }
     }
-
-    // trim leading zeros
-    while (base10Array[base10Array.length] === 0) {
-      base10Array.pop()
-    }
-
-    base10Array.reverse()
-    debug('base10Array: %j', base10Array)
-
-    var bignum = base10Array.join('')
-
-    if (isNegative) {
-      bignum = '-' + bignum
-    }
-    debug('bignum: %s', bignum)
-
-    return bignum
   }
 
-  /** Parse an integer.
-   * Used for reading of integer types and array lengths.
-   * @return The decoded integer.
-   */
-  Marshal.prototype._parseInteger = function() {
-    var small = this.buffer.readInt8(this._index++) // read a signed byte
-    if (small === 0) {
+  // trim leading zeros
+  while (base10Array[ base10Array.length ] === 0) {
+    base10Array.pop()
+  }
+
+  base10Array.reverse()
+  debug('base10Array: %j', base10Array)
+
+  if (isNegative) {
+    base10Array.unshift('-')
+  }
+
+  let bignum = base10Array.join('')
+  debug('bignum: %s', bignum)
+
+  return bignum
+}
+
+/** Parse an integer.
+ * Used for reading of integer types and array lengths.
+ * @return The decoded integer.
+ */
+const _parseInteger = (marshal) => {
+  let small = _parseInt8(marshal) // read a signed byte
+
+  switch (small) {
+    case 0:
       return 0
-    } else if (small >= 6) {
-      return small - 5
-    } else if (small <= -6) {
-      return small + 5
-    } else if (small === 1) {
-      var large = this.buffer.readUInt8(this._index)
-      this._index += 1
-      return large
-    } else if (small === 2) {
-      var large = this.buffer.readUInt16LE(this._index)
-      this._index += 2
-      return large
-    } else if (small === 3) {
-      var large = Buffer.from(
-        this.buffer.toString('hex', this._index, this._index + 3) + '00',
-        'hex'
-      ).readUInt32LE(0)
-      this._index += 3
-      return large
-    } else if (small === 4) {
-      var large = this.buffer.readUInt32LE(this._index)
-      this._index += 4
-      return large
-    } else if (small === -1) {
-      var large = -(~(0xffffff00 + this.buffer.readUInt8(this._index)) + 1)
-      this._index += 1
-      return large
-    } else if (small === -2) {
-      var large = this.buffer.readInt16LE(this._index)
-      this._index += 2
-      return large
-    } else if (small === -3) {
-      var large = -(
-        ~(
-          ((0xffff0000 + this.buffer.readUInt16LE(this._index + 1)) << 8) +
-          this.buffer.readUInt8(this._index)
-        ) + 1
-      )
-      this._index += 3
-      return large
-    } else if (small === -4) {
-      var large = this.buffer.readInt32LE(this._index)
-      this._index += 4
-      return large
-    } else {
-      throw new MarshalError('unable to parse integer', this)
-    }
+    case 1:
+      return _parseUInt8(marshal)
+    case 2:
+      return _parseUInt16LE(marshal)
+    case 3:
+      return _parseUInt24LE(marshal)
+    case 4:
+      return _parseUInt32LE(marshal)
+    case-1:
+      return _parseInt8LE(marshal)
+    case-2:
+      return _parseInt16LE(marshal)
+    case-3:
+      return _parseInt24LE(marshal)
+    case-4:
+      return _parseInt32LE(marshal)
   }
 
-  Marshal.prototype._parseArray = function() {
-    // a = ['foo', 'bar']
-    // \x04\b[\aI\"\bfoo\x06:\x06ETI\"\bbar\x06;\x00T
-    var arr = []
-    var length = this._parseInteger()
-    if (length > 0) {
-      var value
-      while (arr.length < length) {
-        value = this._parse()
-        arr.push(value)
-      }
-    }
-    return arr
+  if (small >= 6) return small - 5
+  if (small <= -6) return small + 5
+
+  throw new MarshalError('unable to parse integer', marshal)
+}
+
+const _parseArray = (marshal) => {
+  // a = ['foo', 'bar']
+  // \x04\b[\aI\"\bfoo\x06:\x06ETI\"\bbar\x06;\x00T
+  const array = []
+  let arrayLength = _parseInteger(marshal)
+  while (arrayLength > 0) {
+    array.push(_parse(marshal))
+    arrayLength--
+  }
+  return array
+}
+
+const _parseObject = (marshal) => {
+  // Object.new
+  // \x04\bo:\vObject\x00
+  // o.instance_variable_set(:@foo, 'bar')
+  // \x04\bo:\vObject\x06:\t@fooI\"\bbar\x06:\x06ET
+  // o.instance_variable_set(:@bar, 'baz')
+  // \x04\bo:\vObject\a:\t@fooI\"\bbar\x06:\x06ET:\t@barI\"\bbaz\x06;\aT
+
+  // symbol name - either a symbol or a symbol link
+  const name = _parse(marshal)
+
+  // hash
+  const object = _parseHash(marshal)
+
+  // attach name
+  object[ '_name' ] = name
+
+  return object
+}
+
+const _parseHash = (marshal) => {
+  // {"first"=>"john", "middle"=>"clay", "last"=>"walker", "age"=>28}
+  // \x04\b{\tI\"\nfirst\x06:\x06ETI\"\tjohn\x06;\x00TI\"\vmiddle\x06;\x00TI\"\tclay\x06;\x00TI\"\tlast\x06;\x00TI\"\vwalker\x06;\x00TI\"\bage\x06;\x00Ti!
+  const hashObject = {}
+  let hashObjectLength = _parseInteger(marshal)
+  while (hashObjectLength > 0) {
+    const key = _parse(marshal)
+    hashObject[ key ] = _parse(marshal)
+    hashObjectLength--
+  }
+  return hashObject
+}
+
+const _parseSymbol = (marshal) => {
+  const symbolString = _parseString(marshal)
+  marshal._symbols.push(symbolString)
+  return symbolString
+}
+
+const _parseSymbolLink = (marshal) => {
+  const index = _parseInteger(marshal)
+  return marshal._symbols[ index ]
+}
+
+const _parseObjectLink = (marshal) => {
+  const index = _parseInteger(marshal)
+  return marshal._objects[ index ]
+}
+
+const _parseString = (marshal) => {
+  const length = _parseInteger(marshal)
+  return _parseBuffer(marshal, length).toString()
+}
+
+const _parseIvar = (marshal) => {
+  const string = _parse(marshal)
+  const lengthOfSymbolChar = _parseInteger(marshal)
+  if (lengthOfSymbolChar !== 1) throw new MarshalError('invalid IVAR, expected a single character', marshal)
+
+  // one character coming up, hopefully a symbol, treat it as a typecode
+  const symbol = _parse(marshal)
+  const value = _parse(marshal)
+  marshal._objects.push(value) // values are saved in the object cache before the ivar
+
+  let encoding
+  if (symbol === 'E') { // 'E' means we have a common encoding, the following boolean determines UTF-8 or ASCII
+    if (value === true) encoding = 'utf8'
+    else encoding = 'ascii'
+  } else if (symbol === 'encoding') { // 'encoding' means we have some other encoding
+    if (value === 'ISO-8859-1') encoding = 'binary'
+    else encoding = value
+  } else throw new MarshalError(`invalid IVAR encoding specification ${symbol}`, marshal)
+
+  const ivar = new Ivar(string, encoding)
+  marshal._objects.push(ivar) // completed ivars are saved in the object cache
+  debug('ivar %s', ivar)
+  return ivar.toString()
+}
+
+class Marshal {
+  constructor (buffer, encoding) {
+    buffer !== undefined && this.load(buffer, encoding)
   }
 
-  Marshal.prototype._parseObject = function() {
-    // Object.new
-    // \x04\bo:\vObject\x00
-    // o.instance_variable_set(:@foo, 'bar')
-    // \x04\bo:\vObject\x06:\t@fooI\"\bbar\x06:\x06ET
-    // o.instance_variable_set(:@bar, 'baz')
-    // \x04\bo:\vObject\a:\t@fooI\"\bbar\x06:\x06ET:\t@barI\"\bbaz\x06;\aT
+  load (buffer, encoding) {
+    if (buffer === undefined || buffer.length === 0) throw new MarshalError('no buffer specified', this)
 
-    // symbol name - either a symbol or a symbol link
-    var name = this._parse()
-
-    // hash
-    var object = this._parseHash()
-
-    // attach name
-    object['_name'] = name
-
-    return object
-  }
-
-  Marshal.prototype._parseHash = function() {
-    // {"first"=>"john", "middle"=>"clay", "last"=>"walker", "age"=>28}
-    // \x04\b{\tI\"\nfirst\x06:\x06ETI\"\tjohn\x06;\x00TI\"\vmiddle\x06;\x00TI\"\tclay\x06;\x00TI\"\tlast\x06;\x00TI\"\vwalker\x06;\x00TI\"\bage\x06;\x00Ti!
-    var hash = {}
-    var length = this._parseInteger()
-    if (length > 0) {
-      var key, value
-      while (Object.keys(hash).length < length) {
-        key = this._parse()
-        value = this._parse()
-        hash[key] = value
-      }
-    }
-    return hash
-  }
-
-  Marshal.prototype._parseSymbol = function() {
-    var symbol = this._parseString()
-    this._symbols.push(symbol)
-    return symbol
-  }
-
-  Marshal.prototype._parseSymbolLink = function() {
-    var index = this._parseInteger()
-    var symbol = this._symbols[index]
-    return symbol
-  }
-
-  Marshal.prototype._parseObjectLink = function() {
-    var index = this._parseInteger()
-    var object = this._objects[index]
-    return object
-  }
-
-  Marshal.prototype._parseString = function() {
-    var length = this._parseInteger()
-    var string = this.buffer.slice(this._index, this._index + length).toString()
-    this._index += length
-    return string
-  }
-
-  Marshal.prototype._parseIvar = function() {
-    var string = this._parse()
-
-    var encoding
-    var lengthOfSymbolChar = this._parseInteger()
-    if (lengthOfSymbolChar === 1) {
-      // one character coming up, hopefully a symbol, treat it as a typecode
-      var symbol = this._parse()
-      var value = this._parse()
-      this._objects.push(value) // values are saved in the object cache before the ivar
-
-      if (symbol === 'E') {
-        // 'E' means we have a common encoding, the following boolean determines UTF-8 or ASCII
-        if (value === true) {
-          encoding = 'utf8'
-        } else {
-          encoding = 'ascii'
-        }
-      } else if (symbol === 'encoding') {
-        // 'encoding' means we have some other encoding
-        if (value === 'ISO-8859-1') {
-          encoding = 'binary'
-        } else {
-          encoding = value
-        }
-      } else {
-        throw new MarshalError(
-          'invalid IVAR encoding specification ' + symbol,
-          this
-        )
-      }
-    } else {
-      throw new MarshalError('invalid IVAR, expected a single character', this)
-    }
-
-    var ivar = new Ivar(string, encoding)
-    this._objects.push(ivar) // completed ivars are saved in the object cache
-    debug('ivar ' + ivar)
-    return ivar.toString()
-  }
-
-  Marshal.prototype.load = function(buffer, encoding) {
-    if (buffer === void 0 || buffer.length === 0) {
-      throw new MarshalError('no buffer specified', this)
-    } else if (buffer instanceof Buffer) {
-      this.buffer = buffer
-    } else {
-      this.buffer = Buffer.from(buffer, encoding)
-    }
-    debug('buffer length ' + this.buffer.length)
+    this.buffer = (buffer instanceof Buffer)
+      ? buffer
+      : Buffer.from(buffer, encoding)
+    debug('buffer length %d', this.buffer.length)
 
     // reset the index
     this._index = 0
 
     // parse Marshal version
-    this._version =
-      this.buffer.readUInt8(this._index++) +
-      '.' +
-      this.buffer.readUInt8(this._index++)
+    this._version = `${_parseUInt8(this)}.${_parseUInt8(this)}`
 
     // create cache tables
     this._symbols = []
     this._objects = []
 
     if (this._index < this.buffer.length) {
-      this.parsed = this._parse()
+      this.parsed = _parse(this)
     }
 
     return this
   }
 
-  // Marshal.prototype.dump = function () {
+  // dump () {
   //   //TODO
   // };
 
-  Marshal.prototype.toString = function(encoding) {
+  toString (encoding) {
     return this.buffer.toString(encoding || 'base64')
   }
 
-  Marshal.prototype.toJSON = function() {
+  toJSON () {
     return this.parsed
   }
-
-  return Marshal
-})()
+}
 
 module.exports = Marshal

--- a/lib/marshal.js
+++ b/lib/marshal.js
@@ -1,222 +1,224 @@
-var debug = require('debug')('marshal');
-var MarshalError = require('./marshalError');
-var Ivar = require('./ivar');
+var debug = require('debug')('marshal')
+var MarshalError = require('./marshalError')
+var Ivar = require('./ivar')
 
 // Copied directly from https://github.com/MikeMcl/decimal.js/blob/fb37ca6bde56676d6d5a98df2bf8721e8fa81085/decimal.js#L27
 // Base conversion alphabet.
-var NUMERALS = '0123456789abcdef';
+var NUMERALS = '0123456789abcdef'
 
-var Marshal;
+var Marshal
 
-Marshal = (function () {
-  function Marshal (buffer, encoding) {
-    if (buffer !== void 0) this.load(buffer, encoding);
+Marshal = (function() {
+  function Marshal(buffer, encoding) {
+    if (buffer !== void 0) this.load(buffer, encoding)
 
-    return this;
-  };
+    return this
+  }
 
-  Marshal.prototype._parse = function () {
-    var typeCode = this.buffer.readUInt8(this._index++);
-    debug('type code ' + '0x' + this.buffer.toString('hex', this._index - 1, this._index) + ' index ' + (this._index - 1));
+  Marshal.prototype._parse = function() {
+    var typeCode = this.buffer.readUInt8(this._index++)
+    debug(
+      'type code ' +
+      '0x' +
+      this.buffer.toString('hex', this._index - 1, this._index) +
+      ' index ' +
+      (this._index - 1)
+    )
     switch (typeCode) {
       case 0x30: // 0 - nil
-        return null;
+        return null
       case 0x54: // T - true
-        return true;
+        return true
       case 0x46: // F - false
-        return false;
+        return false
       case 0x69: // i - integer
-        return this._parseInteger();
+        return this._parseInteger()
       case 0x22: // " - string
-        return this._parseString();
-      case 0x3A: // : - symbol
-        return this._parseSymbol();
-      case 0x3B: // ; - symbol symlink
-        return this._parseSymbolLink();
+        return this._parseString()
+      case 0x3a: // : - symbol
+        return this._parseSymbol()
+      case 0x3b: // ; - symbol symlink
+        return this._parseSymbolLink()
       case 0x40: // @ - object link
-        return this._parseObjectLink();
+        return this._parseObjectLink()
       case 0x49: // I - IVAR (encoded string or regexp)
-        return this._parseIvar();
-      case 0x5B: // [ - array
-        return this._parseArray();
-      case 0x6F: // o - object
-        return this._parseObject();
-      case 0x7B: // { - hash
-        return this._parseHash();
-      case 0x6C: // l - bignum
-        return this._parseBignum();
+        return this._parseIvar()
+      case 0x5b: // [ - array
+        return this._parseArray()
+      case 0x6f: // o - object
+        return this._parseObject()
+      case 0x7b: // { - hash
+        return this._parseHash()
+      case 0x6c: // l - bignum
+        return this._parseBignum()
       case 0x66: // f - float
-        return this._parseFloat();
-      case 0x2F: // / - regexp
+        return this._parseFloat()
+      case 0x2f: // / - regexp
       case 0x63: // c - class
-      case 0x6D: // m - module
+      case 0x6d: // m - module
       default:
-        throw new MarshalError('unsupported typecode ' + typeCode, this);
+        throw new MarshalError('unsupported typecode ' + typeCode, this)
     }
-  };
+  }
 
-  Marshal.prototype._getLength = function () {
-    var length = this.buffer.readInt8(this._index++); // read the number of "machine words" - 16bit integers
+  Marshal.prototype._getLength = function() {
+    var length = this.buffer.readInt8(this._index++) // read the number of "machine words" - 16bit integers
     if (length === 0) {
-      length = 0;
+      length = 0
+    } else if (length >= 6) {
+      length = length - 5
+    } else if (length <= -6) {
+      length = length + 5
     }
-    else if (length >= 6) {
-      length = length - 5;
-    }
-    else if (length <= -6) {
-      length = length + 5;
-    }
-    return length;
-  };
+    return length
+  }
 
   /** Parse a float.
    * @return The decoded float.
    */
-  Marshal.prototype._parseFloat = function () {
-    var length = this._getLength();
-    var floatValue = this.buffer.slice(this._index, this._index + length);
-    this._index = this._index + length;
+  Marshal.prototype._parseFloat = function() {
+    var length = this._getLength()
+    var floatValue = this.buffer.slice(this._index, this._index + length)
+    this._index = this._index + length
     if (floatValue.toString('utf8') === 'inf') {
-      return Infinity;
+      return Infinity
     }
     if (floatValue.toString('utf8') === '-inf') {
-      return -Infinity;
+      return -Infinity
     }
     if (floatValue.toString('utf8') === 'nan') {
-      return NaN;
+      return NaN
     }
-    return parseFloat(floatValue.toString('utf8'));
-  };
-
+    return parseFloat(floatValue.toString('utf8'))
+  }
 
   /** Parse a bignum.
    * @return The decoded bignum.
    */
-  Marshal.prototype._parseBignum = function () {
-    var isNegative = (this.buffer.readInt8(this._index++) === 0x2d); // read the sign byte and check for '-'
-    debug('isNegative: %s', isNegative);
+  Marshal.prototype._parseBignum = function() {
+    var isNegative = this.buffer.readInt8(this._index++) === 0x2d // read the sign byte and check for '-'
+    debug('isNegative: %s', isNegative)
 
     // the word length appears to always be positive but still follows the Marshal length logic
-    var wordLength = this._getLength();
-    debug('wordLength: %s', wordLength);
+    var wordLength = this._getLength()
+    debug('wordLength: %s', wordLength)
 
     // it appears that words are always zero padded - no odd number of bytes
-    var byteLength = wordLength * 2;
-    var byteString = '';
+    var byteLength = wordLength * 2
+    var byteString = ''
     for (var i = 0; i < byteLength; i++, this._index++) {
-      byteString = this.buffer.toString('hex', this._index, this._index + 1) + byteString;
+      byteString =
+        this.buffer.toString('hex', this._index, this._index + 1) + byteString
     }
-    debug('byteString: %j', byteString);
+    debug('byteString: %j', byteString)
 
     // Modified from https://github.com/MikeMcl/decimal.js/blob/fb37ca6bde56676d6d5a98df2bf8721e8fa81085/decimal.js#L2597
-    var base10Array = [0];
-    var i, j, base10ArrayLength;
+    var base10Array = [0]
+    var i, j, base10ArrayLength
     for (i = 0; i < byteString.length; i++) {
-      for (base10ArrayLength = base10Array.length; base10ArrayLength--;) base10Array[base10ArrayLength] *= 16;
-      base10Array[0] += NUMERALS.indexOf(byteString.charAt(i));
+      for (base10ArrayLength = base10Array.length; base10ArrayLength--; )
+        base10Array[base10ArrayLength] *= 16
+      base10Array[0] += NUMERALS.indexOf(byteString.charAt(i))
       for (j = 0; j < base10Array.length; j++) {
         if (base10Array[j] > 10 - 1) {
-          if (base10Array[j + 1] === void 0) base10Array[j + 1] = 0;
-          base10Array[j + 1] += base10Array[j] / 10 | 0;
-          base10Array[j] %= 10;
+          if (base10Array[j + 1] === void 0) base10Array[j + 1] = 0
+          base10Array[j + 1] += (base10Array[j] / 10) | 0
+          base10Array[j] %= 10
         }
       }
     }
 
     // trim leading zeros
     while (base10Array[base10Array.length] === 0) {
-      base10Array.pop();
+      base10Array.pop()
     }
 
-    base10Array.reverse();
-    debug('base10Array: %j', base10Array);
+    base10Array.reverse()
+    debug('base10Array: %j', base10Array)
 
-    var bignum = base10Array.join('');
+    var bignum = base10Array.join('')
 
     if (isNegative) {
-      bignum = '-' + bignum;
+      bignum = '-' + bignum
     }
-    debug('bignum: %s', bignum);
+    debug('bignum: %s', bignum)
 
-    return bignum;
+    return bignum
   }
 
   /** Parse an integer.
    * Used for reading of integer types and array lengths.
    * @return The decoded integer.
    */
-  Marshal.prototype._parseInteger = function () {
-    var small = this.buffer.readInt8(this._index++); // read a signed byte
+  Marshal.prototype._parseInteger = function() {
+    var small = this.buffer.readInt8(this._index++) // read a signed byte
     if (small === 0) {
-      return 0;
+      return 0
+    } else if (small >= 6) {
+      return small - 5
+    } else if (small <= -6) {
+      return small + 5
+    } else if (small === 1) {
+      var large = this.buffer.readUInt8(this._index)
+      this._index += 1
+      return large
+    } else if (small === 2) {
+      var large = this.buffer.readUInt16LE(this._index)
+      this._index += 2
+      return large
+    } else if (small === 3) {
+      var large = Buffer.from(
+        this.buffer.toString('hex', this._index, this._index + 3) + '00',
+        'hex'
+      ).readUInt32LE(0)
+      this._index += 3
+      return large
+    } else if (small === 4) {
+      var large = this.buffer.readUInt32LE(this._index)
+      this._index += 4
+      return large
+    } else if (small === -1) {
+      var large = -(~(0xffffff00 + this.buffer.readUInt8(this._index)) + 1)
+      this._index += 1
+      return large
+    } else if (small === -2) {
+      var large = this.buffer.readInt16LE(this._index)
+      this._index += 2
+      return large
+    } else if (small === -3) {
+      var large = -(
+        ~(
+          ((0xffff0000 + this.buffer.readUInt16LE(this._index + 1)) << 8) +
+          this.buffer.readUInt8(this._index)
+        ) + 1
+      )
+      this._index += 3
+      return large
+    } else if (small === -4) {
+      var large = this.buffer.readInt32LE(this._index)
+      this._index += 4
+      return large
+    } else {
+      throw new MarshalError('unable to parse integer', this)
     }
-    else if (small >= 6) {
-      return small - 5;
-    }
-    else if (small <= -6) {
-      return small + 5;
-    }
-    else if (small === 1) {
-      var large = this.buffer.readUInt8(this._index);
-      this._index += 1;
-      return large;
-    }
-    else if (small === 2) {
-      var large = this.buffer.readUInt16LE(this._index);
-      this._index += 2;
-      return large;
-    }
-    else if (small === 3) {
-      var large = Buffer.from(this.buffer.toString('hex', this._index, this._index + 3) + '00', 'hex').readUInt32LE(0);
-      this._index += 3;
-      return large;
-    }
-    else if (small === 4) {
-      var large = this.buffer.readUInt32LE(this._index);
-      this._index += 4;
-      return large;
-    }
-    else if (small === -1) {
-      var large = -(~(0xffffff00 + this.buffer.readUInt8(this._index)) + 1);
-      this._index += 1;
-      return large;
-    }
-    else if (small === -2) {
-      var large = this.buffer.readInt16LE(this._index);
-      this._index += 2;
-      return large;
-    }
-    else if (small === -3) {
-      var large = -(~(((0xffff0000 + this.buffer.readUInt16LE(this._index + 1)) << 8) + this.buffer.readUInt8(this._index)) + 1);
-      this._index += 3;
-      return large;
-    }
-    else if (small === -4) {
-      var large = this.buffer.readInt32LE(this._index);
-      this._index += 4;
-      return large;
-    }
-    else {
-      throw new MarshalError('unable to parse integer', this);
-    }
-  };
+  }
 
-  Marshal.prototype._parseArray = function () {
+  Marshal.prototype._parseArray = function() {
     // a = ['foo', 'bar']
     // \x04\b[\aI\"\bfoo\x06:\x06ETI\"\bbar\x06;\x00T
-    var arr = [];
-    var length = this._parseInteger();
+    var arr = []
+    var length = this._parseInteger()
     if (length > 0) {
-      var value;
+      var value
       while (arr.length < length) {
-        value = this._parse();
-        arr.push(value);
+        value = this._parse()
+        arr.push(value)
       }
     }
-    return arr;
-  };
+    return arr
+  }
 
-  Marshal.prototype._parseObject = function () {
+  Marshal.prototype._parseObject = function() {
     // Object.new
     // \x04\bo:\vObject\x00
     // o.instance_variable_set(:@foo, 'bar')
@@ -225,142 +227,142 @@ Marshal = (function () {
     // \x04\bo:\vObject\a:\t@fooI\"\bbar\x06:\x06ET:\t@barI\"\bbaz\x06;\aT
 
     // symbol name - either a symbol or a symbol link
-    var name = this._parse();
+    var name = this._parse()
 
     // hash
-    var object = this._parseHash();
+    var object = this._parseHash()
 
     // attach name
-    object['_name'] = name;
+    object['_name'] = name
 
-    return object;
-  };
+    return object
+  }
 
-  Marshal.prototype._parseHash = function () {
+  Marshal.prototype._parseHash = function() {
     // {"first"=>"john", "middle"=>"clay", "last"=>"walker", "age"=>28}
     // \x04\b{\tI\"\nfirst\x06:\x06ETI\"\tjohn\x06;\x00TI\"\vmiddle\x06;\x00TI\"\tclay\x06;\x00TI\"\tlast\x06;\x00TI\"\vwalker\x06;\x00TI\"\bage\x06;\x00Ti!
-    var hash = {};
-    var length = this._parseInteger();
+    var hash = {}
+    var length = this._parseInteger()
     if (length > 0) {
-      var key, value;
+      var key, value
       while (Object.keys(hash).length < length) {
-        key = this._parse();
-        value = this._parse();
-        hash[key] = value;
+        key = this._parse()
+        value = this._parse()
+        hash[key] = value
       }
     }
-    return hash;
-  };
+    return hash
+  }
 
-  Marshal.prototype._parseSymbol = function () {
-    var symbol = this._parseString();
-    this._symbols.push(symbol);
-    return symbol;
-  };
+  Marshal.prototype._parseSymbol = function() {
+    var symbol = this._parseString()
+    this._symbols.push(symbol)
+    return symbol
+  }
 
-  Marshal.prototype._parseSymbolLink = function () {
-    var index = this._parseInteger();
-    var symbol = this._symbols[index];
-    return symbol;
-  };
+  Marshal.prototype._parseSymbolLink = function() {
+    var index = this._parseInteger()
+    var symbol = this._symbols[index]
+    return symbol
+  }
 
-  Marshal.prototype._parseObjectLink = function () {
-    var index = this._parseInteger();
-    var object = this._objects[index];
-    return object;
-  };
+  Marshal.prototype._parseObjectLink = function() {
+    var index = this._parseInteger()
+    var object = this._objects[index]
+    return object
+  }
 
-  Marshal.prototype._parseString = function () {
-    var length = this._parseInteger();
-    var string = this.buffer.slice(this._index, this._index + length).toString();
-    this._index += length;
-    return string;
-  };
+  Marshal.prototype._parseString = function() {
+    var length = this._parseInteger()
+    var string = this.buffer.slice(this._index, this._index + length).toString()
+    this._index += length
+    return string
+  }
 
-  Marshal.prototype._parseIvar = function () {
-    var string = this._parse();
+  Marshal.prototype._parseIvar = function() {
+    var string = this._parse()
 
-    var encoding;
-    var lengthOfSymbolChar = this._parseInteger();
+    var encoding
+    var lengthOfSymbolChar = this._parseInteger()
     if (lengthOfSymbolChar === 1) {
       // one character coming up, hopefully a symbol, treat it as a typecode
-      var symbol = this._parse();
-      var value = this._parse();
-      this._objects.push(value); // values are saved in the object cache before the ivar
+      var symbol = this._parse()
+      var value = this._parse()
+      this._objects.push(value) // values are saved in the object cache before the ivar
 
       if (symbol === 'E') {
         // 'E' means we have a common encoding, the following boolean determines UTF-8 or ASCII
         if (value === true) {
-          encoding = 'utf8';
+          encoding = 'utf8'
+        } else {
+          encoding = 'ascii'
         }
-        else {
-          encoding = 'ascii';
-        }
-      }
-      else if (symbol === 'encoding') {
+      } else if (symbol === 'encoding') {
         // 'encoding' means we have some other encoding
         if (value === 'ISO-8859-1') {
-          encoding = 'binary';
+          encoding = 'binary'
         } else {
-          encoding = value;
+          encoding = value
         }
+      } else {
+        throw new MarshalError(
+          'invalid IVAR encoding specification ' + symbol,
+          this
+        )
       }
-      else {
-        throw new MarshalError('invalid IVAR encoding specification ' + symbol, this);
-      }
-    }
-    else {
-      throw new MarshalError('invalid IVAR, expected a single character', this);
+    } else {
+      throw new MarshalError('invalid IVAR, expected a single character', this)
     }
 
-    var ivar = new Ivar(string, encoding);
-    this._objects.push(ivar); // completed ivars are saved in the object cache
-    debug('ivar ' + ivar);
-    return ivar.toString();
-  };
+    var ivar = new Ivar(string, encoding)
+    this._objects.push(ivar) // completed ivars are saved in the object cache
+    debug('ivar ' + ivar)
+    return ivar.toString()
+  }
 
-  Marshal.prototype.load = function (buffer, encoding) {
+  Marshal.prototype.load = function(buffer, encoding) {
     if (buffer === void 0 || buffer.length === 0) {
-      throw new MarshalError('no buffer specified', this);
+      throw new MarshalError('no buffer specified', this)
+    } else if (buffer instanceof Buffer) {
+      this.buffer = buffer
+    } else {
+      this.buffer = Buffer.from(buffer, encoding)
     }
-    else if (buffer instanceof Buffer) {
-      this.buffer = buffer;
-    }
-    else {
-      this.buffer = Buffer.from(buffer, encoding);
-    }
-    debug('buffer length ' + this.buffer.length);
+    debug('buffer length ' + this.buffer.length)
 
     // reset the index
-    this._index = 0;
+    this._index = 0
 
     // parse Marshal version
-    this._version = this.buffer.readUInt8(this._index++) + '.' + this.buffer.readUInt8(this._index++);
+    this._version =
+      this.buffer.readUInt8(this._index++) +
+      '.' +
+      this.buffer.readUInt8(this._index++)
 
     // create cache tables
-    this._symbols = [];
-    this._objects = [];
+    this._symbols = []
+    this._objects = []
 
     if (this._index < this.buffer.length) {
-      this.parsed = this._parse();
+      this.parsed = this._parse()
     }
 
-    return this;
-  };
+    return this
+  }
 
   // Marshal.prototype.dump = function () {
   //   //TODO
   // };
 
-  Marshal.prototype.toString = function (encoding) {
-    return this.buffer.toString(encoding || 'base64');
-  };
+  Marshal.prototype.toString = function(encoding) {
+    return this.buffer.toString(encoding || 'base64')
+  }
 
-  Marshal.prototype.toJSON = function () {
-    return this.parsed;
-  };
+  Marshal.prototype.toJSON = function() {
+    return this.parsed
+  }
 
-  return Marshal;
-})();
+  return Marshal
+})()
 
-module.exports = Marshal;
+module.exports = Marshal

--- a/lib/marshalError.js
+++ b/lib/marshalError.js
@@ -1,42 +1,28 @@
-var debug = require('debug')('marshal')
-var util = require('util')
+const { debug, IS_DEBUG } = require('./debug')
 
-var MarshalError
+// https://stackoverflow.com/questions/1382107/whats-a-good-way-to-extend-error-in-javascript
 
-MarshalError = (function() {
-  function MarshalError(message, instance) {
-    this.name = 'MarshalError'
-    this.message =
-      message +
-      ' (index: ' +
-      (instance._index - 1) +
-      ', hex: ' +
-      instance.buffer.toString('hex', instance._index - 1, instance._index) +
-      ', utf8: ' +
-      instance.buffer.toString('utf8', instance._index - 1, instance._index) +
-      ')'
-    debug(
-      'buffer hex: ' +
-      instance.buffer.toString('hex', 0, instance._index - 1) +
-      ' ' +
-      instance.buffer.toString('hex', instance._index - 1, instance._index) +
-      ' ' +
-      instance.buffer.toString('hex', instance._index)
-    )
-    debug(
-      'buffer string: ' +
-      instance.buffer.toString('utf8', 0, instance._index - 1) +
-      ' ' +
-      instance.buffer.toString('utf8', instance._index - 1, instance._index) +
-      ' ' +
-      instance.buffer.toString('utf8', instance._index)
-    )
-    Error.captureStackTrace(this, this.constructor)
-  }
+function MarshalError (message, instance) {
+  const buffer = instance.buffer
+  const index = instance._index - 1
+  const indexTo = instance._index
 
-  util.inherits(MarshalError, Error)
+  this.message = `${message} (index: ${index}, hex: ${buffer.toString('hex', index, indexTo)}, utf8: ${buffer.toString('utf8', index, indexTo)})`
+  this.stack = Error().stack
 
-  return MarshalError
-})()
+  IS_DEBUG && debug('buffer hex: %s %s %s',
+    buffer.toString('hex', 0, index),
+    buffer.toString('hex', index, indexTo),
+    buffer.toString('hex', indexTo)
+  )
+  IS_DEBUG && debug('buffer string: %s %s %s',
+    buffer.toString('utf8', 0, index),
+    buffer.toString('utf8', index, indexTo),
+    buffer.toString('utf8', indexTo)
+  )
+}
+
+MarshalError.prototype = Object.create(Error.prototype)
+MarshalError.prototype.name = 'MarshalError'
 
 module.exports = MarshalError

--- a/lib/marshalError.js
+++ b/lib/marshalError.js
@@ -1,29 +1,42 @@
-var debug = require('debug')('marshal');
-var util = require('util');
+var debug = require('debug')('marshal')
+var util = require('util')
 
-var MarshalError;
+var MarshalError
 
-MarshalError = (function () {
-  function MarshalError (message, instance) {
-    this.name = 'MarshalError';
-    this.message = message +
-      ' (index: ' + (instance._index - 1) +
-      ', hex: ' + instance.buffer.toString('hex', instance._index - 1, instance._index) +
-      ', utf8: ' + instance.buffer.toString('utf8', instance._index - 1, instance._index) + ')';
-    debug('buffer hex: ' +
-        instance.buffer.toString('hex', 0, instance._index - 1) + ' ' +
-        instance.buffer.toString('hex', instance._index - 1, instance._index) + ' ' +
-        instance.buffer.toString('hex', instance._index));
-    debug('buffer string: ' +
-        instance.buffer.toString('utf8', 0, instance._index - 1) + ' ' +
-        instance.buffer.toString('utf8', instance._index - 1, instance._index) + ' ' +
-        instance.buffer.toString('utf8', instance._index));
-    Error.captureStackTrace(this, this.constructor);
-  };
+MarshalError = (function() {
+  function MarshalError(message, instance) {
+    this.name = 'MarshalError'
+    this.message =
+      message +
+      ' (index: ' +
+      (instance._index - 1) +
+      ', hex: ' +
+      instance.buffer.toString('hex', instance._index - 1, instance._index) +
+      ', utf8: ' +
+      instance.buffer.toString('utf8', instance._index - 1, instance._index) +
+      ')'
+    debug(
+      'buffer hex: ' +
+      instance.buffer.toString('hex', 0, instance._index - 1) +
+      ' ' +
+      instance.buffer.toString('hex', instance._index - 1, instance._index) +
+      ' ' +
+      instance.buffer.toString('hex', instance._index)
+    )
+    debug(
+      'buffer string: ' +
+      instance.buffer.toString('utf8', 0, instance._index - 1) +
+      ' ' +
+      instance.buffer.toString('utf8', instance._index - 1, instance._index) +
+      ' ' +
+      instance.buffer.toString('utf8', instance._index)
+    )
+    Error.captureStackTrace(this, this.constructor)
+  }
 
-  util.inherits(MarshalError, Error);
+  util.inherits(MarshalError, Error)
 
-  return MarshalError;
-})();
+  return MarshalError
+})()
 
-module.exports = MarshalError;
+module.exports = MarshalError

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "codecov": "codecov -f ./coverage/lcov.info -t 89a2b49e-cb3c-4349-91c0-3403e4a75303 --disable=gcov",
     "coverage": "nyc report --reporter=lcov",
-    "test": "nyc tape test/*.js"
+    "test": "nyc tape test/*.js",
+    "test-only": "npx cross-env DEBUG=marshal tape test/*.js"
   },
   "repository": {
     "type": "git",
@@ -25,7 +26,7 @@
   },
   "homepage": "https://github.com/clayzermk1/node-marshal",
   "engines": {
-    "node": ">=6.11.5"
+    "node": ">=8"
   },
   "dependencies": {
     "debug": "4.1.1"

--- a/test/marshal.js
+++ b/test/marshal.js
@@ -1,290 +1,294 @@
-var test = require('tape');
-var Marshal = require('../index.js');
+const test = require('tape')
+const Marshal = require('../index.js')
 
-// NOTE: Marshal.dump(<var>).unpack('H*') is invaluable for creating these buffer strings in hex
-var version = Buffer.from('0408', 'hex');
-var nily = Buffer.from('040830', 'hex');
-var truey = Buffer.from('040854', 'hex');
-var falsey = Buffer.from('040846', 'hex');
-var intyZero = Buffer.from('04086900', 'hex');
-var intyOne = Buffer.from('04086906', 'hex');
-var intyOneTwoThree = Buffer.from('040869017b', 'hex');
-var intyOneFiveZero = Buffer.from('0408690196', 'hex');
-var intyTwoFiveSix = Buffer.from('040869020001', 'hex');
-var intySixFiveFiveThreeSix = Buffer.from('04086903000001', 'hex');
-var intyTwoPowerThirtyMinusOne = Buffer.from('04086904ffffff3f', 'hex');
-var intyNegOne = Buffer.from('040869fa', 'hex');
-var intyNegOneTwoFour = Buffer.from('040869ff84', 'hex');
-var intyNegOneTwoNine = Buffer.from('040869ff7f', 'hex');
-var intyNegOneFiveZero = Buffer.from('040869ff6a', 'hex');
-var intyNegTwoFiveSeven = Buffer.from('040869fefffe', 'hex');
-var intyNegTwoFiveSix = Buffer.from('040869ff00', 'hex');
-var intyNegSixFiveFiveThreeSeven = Buffer.from('040869fdfffffe', 'hex');
-var intyNegTwoPowerThirty = Buffer.from('040869fc000000c0', 'hex');
-var bigIntyTwoPowerThirty = Buffer.from('04086c2b0700000040', 'hex'); // Ruby smallest positive bignum
-var bigIntyTwoPowerFiftyThreeMinusOne = Buffer.from('04086c2b09ffffffffffff1f00', 'hex'); // JS Number max safe integer
-var bigIntyNegTwoPowerThirtyMinusOne = Buffer.from('04086c2d0701000040', 'hex'); // Ruby smallest negative bignum
-var bigIntyNegTwoPowerFiftyThreeMinusOne = Buffer.from('04086c2d09ffffffffffff1f00', 'hex'); // JS Number min safe integer
-var symbolyHello = Buffer.from('04083a0a68656c6c6f', 'hex');
-var symbolLinkyHello = Buffer.from('04085b073a0a68656c6c6f3b00', 'hex');
-var objectLinkyHello = Buffer.from('04085b0749220a68656c6c6f063a0645544006', 'hex');
-var objectNameIsLink = Buffer.from('04085b085b263a0773313a0773323a0773333a0773343a0773353a0773363a0773373a0773383a0773393a087331303a087331313a087331323a087331333a087331343a087331353a087331363a087331373a087331383a087331393a087332303a087332313a087332323a087332333a087332343a087332353a087332363a087332373a087332383a087332393a087333303a087333313a087333323a087333336f3a0642006f3b2600', 'hex'); // #6
-var stringyEmpty = Buffer.from('04082200', 'hex');
-var stringyHello = Buffer.from('0408220a68656c6c6f', 'hex');
-var ivaryHelloUtf = Buffer.from('040849220a68656c6c6f063a064554', 'hex');
-var ivaryHelloAscii = Buffer.from('040849220a68656c6c6f063a064546', 'hex');
-var ivaryHelloIso8859Dash1 = Buffer.from('040849220a68656c6c6f063a0d656e636f64696e67220f49534f2d383835392d31', 'hex');
-var ivaryLorem = Buffer.from('04082201f64c6f72656d20697073756d20646f6c6f722073697420616d65742c20636f6e7365637465747572206164697069736963696e6720656c69742e20526570656c6c617420766f6c757074617320726572756d20656f7320656c6967656e64692c20647563696d7573206c61626f72756d206578706c696361626f2074656d706f72696275732076656c206970736120657865726369746174696f6e656d2070726f766964656e74206f62636165636174692065756d206c61626f72652065787065646974612061747175652c20646f6c6f72656d717565206c61626f72696f73616d206e6973692c20726570726568656e64657269742e063a064554', 'hex');
-var arrayyEmpty = Buffer.from('04085b00', 'hex');
-var arrayyInteger = Buffer.from('04085b066906', 'hex');
-var objectyEmpty = Buffer.from('04086f3a0b4f626a65637400', 'hex');
-var objectyFoo = Buffer.from('04086f3a0b4f626a656374063a0940666f6f492208626172063a064554', 'hex');
-var hashyEmpty = Buffer.from('04087b00', 'hex');
-var hashyOneTwo = Buffer.from('04087b0669066907', 'hex');
-var railsSessionCookie = Buffer.from('04087b0b49220f73657373696f6e5f6964063a0645544922253836663666666139323537363739653231633733306236376138626263363233063b00544922105f637372665f746f6b656e063b004649223175557364487970586e6576346a6a4932646f554271317049795270637a5959536c443968354c78445a51553d063b004649220c757365725f6964063b004649220196636f6e6e6563742e736573733d732533416a2533412537422532327573657225323225334125323230313631626663652d616665302d346239652d386265382d6530323637653263646465322532322537442e4c4664327a652532465973316750744979456f597257665861747464633144774a353469576c332532462532426a6b35553b20506174683d2f3b20487474704f6e6c79063b005449221270617373776f72645f68617368063b00464922253334666263633762663264306265613335356164373938653032383938663563063b00464922106c6f636174696f6e5f6964063b004649222932356239306561632d303736392d343864382d393866612d383861343863633830376138063b005449220f6163636f756e745f6964063b004649222939363661656139662d636266302d346137392d383061642d623131633966393565626130063b0054', 'hex');
-var floatyPositive = Buffer.from('0408660c31322e33343536', 'hex');
-var floatyNegative = Buffer.from('0408660d2d31322e33343536', 'hex');
-var floatyPositiveInfinity = Buffer.from('04086608696e66', 'hex');
-var floatyNegativeInfinity = Buffer.from('040866092d696e66', 'hex');
-var floatyNaN = Buffer.from('040866086e616e', 'hex');
+// NOTE: Marshal.dump(<const>).unpack('H*') is invaluable for creating these buffer strings in hex
+const version = Buffer.from('0408', 'hex')
+const nily = Buffer.from('040830', 'hex')
+const truey = Buffer.from('040854', 'hex')
+const falsey = Buffer.from('040846', 'hex')
+const intyZero = Buffer.from('04086900', 'hex')
+const intyOne = Buffer.from('04086906', 'hex')
+const intyOneTwoThree = Buffer.from('040869017b', 'hex')
+const intyOneFiveZero = Buffer.from('0408690196', 'hex')
+const intyTwoFiveSix = Buffer.from('040869020001', 'hex')
+const intySixFiveFiveThreeSix = Buffer.from('04086903000001', 'hex')
+const intyTwoPowerThirtyMinusOne = Buffer.from('04086904ffffff3f', 'hex')
+const intyNegOne = Buffer.from('040869fa', 'hex')
+const intyNegOneTwoFour = Buffer.from('040869ff84', 'hex')
+const intyNegOneTwoNine = Buffer.from('040869ff7f', 'hex')
+const intyNegOneFiveZero = Buffer.from('040869ff6a', 'hex')
+const intyNegTwoFiveSeven = Buffer.from('040869fefffe', 'hex')
+const intyNegTwoFiveSix = Buffer.from('040869ff00', 'hex')
+const intyNegSixFiveFiveThreeSeven = Buffer.from('040869fdfffffe', 'hex')
+const intyNegTwoPowerThirty = Buffer.from('040869fc000000c0', 'hex')
+const bigIntyTwoPowerThirty = Buffer.from('04086c2b0700000040', 'hex') // Ruby smallest positive bignum
+const bigIntyTwoPowerFiftyThreeMinusOne = Buffer.from('04086c2b09ffffffffffff1f00', 'hex') // JS Number max safe integer
+const bigIntyNegTwoPowerThirtyMinusOne = Buffer.from('04086c2d0701000040', 'hex') // Ruby smallest negative bignum
+const bigIntyNegTwoPowerFiftyThreeMinusOne = Buffer.from('04086c2d09ffffffffffff1f00', 'hex') // JS Number min safe integer
+const symbolyHello = Buffer.from('04083a0a68656c6c6f', 'hex')
+const symbolLinkyHello = Buffer.from('04085b073a0a68656c6c6f3b00', 'hex')
+const objectLinkyHello = Buffer.from('04085b0749220a68656c6c6f063a0645544006', 'hex')
+const objectNameIsLink = Buffer.from('04085b085b263a0773313a0773323a0773333a0773343a0773353a0773363a0773373a0773383a0773393a087331303a087331313a087331323a087331333a087331343a087331353a087331363a087331373a087331383a087331393a087332303a087332313a087332323a087332333a087332343a087332353a087332363a087332373a087332383a087332393a087333303a087333313a087333323a087333336f3a0642006f3b2600', 'hex') // #6
+const stringyEmpty = Buffer.from('04082200', 'hex')
+const stringyHello = Buffer.from('0408220a68656c6c6f', 'hex')
+const ivaryHelloUtf = Buffer.from('040849220a68656c6c6f063a064554', 'hex')
+const ivaryHelloAscii = Buffer.from('040849220a68656c6c6f063a064546', 'hex')
+const ivaryHelloIso8859Dash1 = Buffer.from('040849220a68656c6c6f063a0d656e636f64696e67220f49534f2d383835392d31', 'hex')
+const ivaryLorem = Buffer.from('04082201f64c6f72656d20697073756d20646f6c6f722073697420616d65742c20636f6e7365637465747572206164697069736963696e6720656c69742e20526570656c6c617420766f6c757074617320726572756d20656f7320656c6967656e64692c20647563696d7573206c61626f72756d206578706c696361626f2074656d706f72696275732076656c206970736120657865726369746174696f6e656d2070726f766964656e74206f62636165636174692065756d206c61626f72652065787065646974612061747175652c20646f6c6f72656d717565206c61626f72696f73616d206e6973692c20726570726568656e64657269742e063a064554', 'hex')
+const arrayyEmpty = Buffer.from('04085b00', 'hex')
+const arrayyInteger = Buffer.from('04085b066906', 'hex')
+const objectyEmpty = Buffer.from('04086f3a0b4f626a65637400', 'hex')
+const objectyFoo = Buffer.from('04086f3a0b4f626a656374063a0940666f6f492208626172063a064554', 'hex')
+const hashyEmpty = Buffer.from('04087b00', 'hex')
+const hashyOneTwo = Buffer.from('04087b0669066907', 'hex')
+const railsSessionCookie = Buffer.from('04087b0b49220f73657373696f6e5f6964063a0645544922253836663666666139323537363739653231633733306236376138626263363233063b00544922105f637372665f746f6b656e063b004649223175557364487970586e6576346a6a4932646f554271317049795270637a5959536c443968354c78445a51553d063b004649220c757365725f6964063b004649220196636f6e6e6563742e736573733d732533416a2533412537422532327573657225323225334125323230313631626663652d616665302d346239652d386265382d6530323637653263646465322532322537442e4c4664327a652532465973316750744979456f597257665861747464633144774a353469576c332532462532426a6b35553b20506174683d2f3b20487474704f6e6c79063b005449221270617373776f72645f68617368063b00464922253334666263633762663264306265613335356164373938653032383938663563063b00464922106c6f636174696f6e5f6964063b004649222932356239306561632d303736392d343864382d393866612d383861343863633830376138063b005449220f6163636f756e745f6964063b004649222939363661656139662d636266302d346137392d383061642d623131633966393565626130063b0054', 'hex')
+const floatyPositive = Buffer.from('0408660c31322e33343536', 'hex')
+const floatyNegative = Buffer.from('0408660d2d31322e33343536', 'hex')
+const floatyPositiveInfinity = Buffer.from('04086608696e66', 'hex')
+const floatyNegativeInfinity = Buffer.from('040866092d696e66', 'hex')
+const floatyNaN = Buffer.from('040866086e616e', 'hex')
 
-test('marshal', function (t) {
-  t.test('parse', function (t) {
-    var m = new Marshal();
-    t.test('version', function (t) {
-      t.equal(m.load(version)._version, '4.8', 'should equal 4.8');
-      t.end();
-    });
+test('marshal', (t) => {
+  t.test('parse', (t) => {
+    const m = new Marshal()
+    t.test('version', (t) => {
+      t.equal(m.load(version)._version, '4.8', 'should equal 4.8')
+      t.end()
+    })
 
-    t.test('nil', function (t) {
-      t.equal(m.load(nily).parsed, null, 'should equal null');
-      t.end();
-    });
+    t.test('nil', (t) => {
+      t.equal(m.load(nily).parsed, null, 'should equal null')
+      t.end()
+    })
 
-    t.test('booleans', function (t) {
-      t.test('true', function (t) {
-        t.equal(m.load(truey).parsed, true, 'should equal true');
-        t.end();
-      });
-      t.test('false', function (t) {
-        t.equal(m.load(falsey).parsed, false, 'should equal false');
-        t.end();
-      });
-      t.end();
-    });
+    t.test('booleans', (t) => {
+      t.test('true', (t) => {
+        t.equal(m.load(truey).parsed, true, 'should equal true')
+        t.end()
+      })
+      t.test('false', (t) => {
+        t.equal(m.load(falsey).parsed, false, 'should equal false')
+        t.end()
+      })
+      t.end()
+    })
 
-    t.test('integers', function (t) {
-      t.test('0', function (t) {
-        t.equal(m.load(intyZero).parsed, 0, 'should equal 0');
-        t.end();
-      });
-      t.test('1', function (t) {
-        t.equal(m.load(intyOne).parsed, 1, 'should equal 1');
-        t.end();
-      });
-      t.test('123', function (t) {
-        t.equal(m.load(intyOneTwoThree).parsed, 123, 'should equal 123');
-        t.end();
-      });
-      t.test('150', function (t) {
-        t.equal(m.load(intyOneFiveZero).parsed, 150, 'should equal 150');
-        t.end();
-      });
-      t.test('256', function (t) {
-        t.equal(m.load(intyTwoFiveSix).parsed, 256, 'should equal 256');
-        t.end();
-      });
-      t.test('65536', function (t) {
-        t.equal(m.load(intySixFiveFiveThreeSix).parsed, 65536, 'should equal 65536');
-        t.end();
-      });
-      t.test('2^30 - 1', function (t) {
-        t.equal(m.load(intyTwoPowerThirtyMinusOne).parsed, Math.pow(2, 30) - 1, 'should equal 2^30 - 1');
-        t.end();
-      });
-      t.test('-1', function (t) {
-        t.equal(m.load(intyNegOne).parsed, -1, 'should equal -1');
-        t.end();
-      });
-      t.test('-124', function (t) {
-        t.equal(m.load(intyNegOneTwoFour).parsed, -124, 'should equal -124');
-        t.end();
-      });
-      t.test('-129', function (t) {
-        t.equals(m.load(intyNegOneTwoNine).parsed, -129, 'should equal -129');
-        t.end();
-      });
-      t.test('-150', function (t) {
-        t.equals(m.load(intyNegOneFiveZero).parsed, -150, 'should equal -150');
-        t.end();
-      });
-      t.test('-256', function (t) {
-        t.equals(m.load(intyNegTwoFiveSix).parsed, -256, 'should equal -256');
-        t.end();
-      });
-      t.test('-257', function (t) {
-        t.equal(m.load(intyNegTwoFiveSeven).parsed, -257, 'should equal -257');
-        t.end();
-      });
-      t.test('-65537', function (t) {
-        t.equal(m.load(intyNegSixFiveFiveThreeSeven).parsed, -65537, 'should equal -65537');
-        t.end();
-      });
-      t.test('-2^30', function (t) {
-        t.equal(m.load(intyNegTwoPowerThirty).parsed, -Math.pow(2, 30), 'should equal -2^30');
-        t.end();
-      });
-      t.end();
-    });
+    t.test('integers', (t) => {
+      t.test('0', (t) => {
+        t.equal(m.load(intyZero).parsed, 0, 'should equal 0')
+        t.end()
+      })
+      t.test('1', (t) => {
+        t.equal(m.load(intyOne).parsed, 1, 'should equal 1')
+        t.end()
+      })
+      t.test('123', (t) => {
+        t.equal(m.load(intyOneTwoThree).parsed, 123, 'should equal 123')
+        t.end()
+      })
+      t.test('150', (t) => {
+        t.equal(m.load(intyOneFiveZero).parsed, 150, 'should equal 150')
+        t.end()
+      })
+      t.test('256', (t) => {
+        t.equal(m.load(intyTwoFiveSix).parsed, 256, 'should equal 256')
+        t.end()
+      })
+      t.test('65536', (t) => {
+        t.equal(m.load(intySixFiveFiveThreeSix).parsed, 65536, 'should equal 65536')
+        t.end()
+      })
+      t.test('2^30 - 1', (t) => {
+        t.equal(m.load(intyTwoPowerThirtyMinusOne).parsed, Math.pow(2, 30) - 1, 'should equal 2^30 - 1')
+        t.end()
+      })
+      t.test('-1', (t) => {
+        t.equal(m.load(intyNegOne).parsed, -1, 'should equal -1')
+        t.end()
+      })
+      t.test('-124', (t) => {
+        t.equal(m.load(intyNegOneTwoFour).parsed, -124, 'should equal -124')
+        t.end()
+      })
+      t.test('-129', (t) => {
+        t.equals(m.load(intyNegOneTwoNine).parsed, -129, 'should equal -129')
+        t.end()
+      })
+      t.test('-150', (t) => {
+        t.equals(m.load(intyNegOneFiveZero).parsed, -150, 'should equal -150')
+        t.end()
+      })
+      t.test('-256', (t) => {
+        t.equals(m.load(intyNegTwoFiveSix).parsed, -256, 'should equal -256')
+        t.end()
+      })
+      t.test('-257', (t) => {
+        t.equal(m.load(intyNegTwoFiveSeven).parsed, -257, 'should equal -257')
+        t.end()
+      })
+      t.test('-65537', (t) => {
+        t.equal(m.load(intyNegSixFiveFiveThreeSeven).parsed, -65537, 'should equal -65537')
+        t.end()
+      })
+      t.test('-2^30', (t) => {
+        t.equal(m.load(intyNegTwoPowerThirty).parsed, -Math.pow(2, 30), 'should equal -2^30')
+        t.end()
+      })
+      t.end()
+    })
 
-    t.test('bignums', function (t) {
-      t.test('2^30', function (t) {
-        t.equal(m.load(bigIntyTwoPowerThirty).parsed, '1073741824', 'should equal "1073741824"');
-        t.end();
-      });
-      t.test('2^53 - 1', function (t) {
-        t.equal(m.load(bigIntyTwoPowerFiftyThreeMinusOne).parsed, '9007199254740991', 'should equal "9007199254740991"');
-        t.end();
-      });
-      t.test('-2^30 - 1', function (t) {
-        t.equal(m.load(bigIntyNegTwoPowerThirtyMinusOne).parsed, '-1073741825', 'should equal "-1073741825"');
-        t.end();
-      });
-      t.test('-2^53 - 1', function (t) {
-        t.equal(m.load(bigIntyNegTwoPowerFiftyThreeMinusOne).parsed, '-9007199254740991', 'should equal "-9007199254740991"');
-        t.end();
-      });
-    });
+    t.test('bignums', (t) => {
+      t.test('2^30', (t) => {
+        t.equal(m.load(bigIntyTwoPowerThirty).parsed, '1073741824', 'should equal "1073741824"')
+        t.end()
+      })
+      t.test('2^53 - 1', (t) => {
+        t.equal(m.load(bigIntyTwoPowerFiftyThreeMinusOne).parsed, '9007199254740991', 'should equal "9007199254740991"')
+        t.end()
+      })
+      t.test('-2^30 - 1', (t) => {
+        t.equal(m.load(bigIntyNegTwoPowerThirtyMinusOne).parsed, '-1073741825', 'should equal "-1073741825"')
+        t.end()
+      })
+      t.test('-2^53 - 1', (t) => {
+        t.equal(m.load(bigIntyNegTwoPowerFiftyThreeMinusOne).parsed, '-9007199254740991', 'should equal "-9007199254740991"')
+        t.end()
+      })
+    })
 
-    t.test('strings', function (t) {
-      t.test('<empty>', function (t) {
-        t.equal(m.load(stringyEmpty).parsed, '', 'should equal ""');
-        t.end();
-      });
-      t.test('hello', function (t) {
-        t.equal(m.load(stringyHello).parsed, 'hello', 'should equal "hello"');
-        t.end();
-      });
-      t.end();
-    });
+    t.test('strings', (t) => {
+      t.test('<empty>', (t) => {
+        t.equal(m.load(stringyEmpty).parsed, '', 'should equal ""')
+        t.end()
+      })
+      t.test('hello', (t) => {
+        t.equal(m.load(stringyHello).parsed, 'hello', 'should equal "hello"')
+        t.end()
+      })
+      t.end()
+    })
 
-    t.test('symbols', function (t) {
-      t.test(':hello', function (t) {
-        t.equal(m.load(symbolyHello).parsed, 'hello', 'should equal "hello"');
-        t.end();
-      });
-      t.end();
-    });
+    t.test('symbols', (t) => {
+      t.test(':hello', (t) => {
+        t.equal(m.load(symbolyHello).parsed, 'hello', 'should equal "hello"')
+        t.end()
+      })
+      t.end()
+    })
 
-    t.test('symbol links', function (t) {
-      t.test(';0', function (t) {
-        t.equal(m.load(symbolLinkyHello).parsed[1], 'hello', 'should equal "hello"');
-        t.end();
-      });
-      t.end();
-    });
+    t.test('symbol links', (t) => {
+      t.test(';0', (t) => {
+        t.equal(m.load(symbolLinkyHello).parsed[ 1 ], 'hello', 'should equal "hello"')
+        t.end()
+      })
+      t.end()
+    })
 
-    t.test('object links', function (t) {
-      t.test('@0', function (t) {
-        t.equal('' + m.load(objectLinkyHello).parsed[1], 'hello', 'should equal "hello"');
-        t.end();
-      });
-      t.end();
-    });
+    t.test('object links', (t) => {
+      t.test('@0', (t) => {
+        t.equal('' + m.load(objectLinkyHello).parsed[ 1 ], 'hello', 'should equal "hello"')
+        t.end()
+      })
+      t.end()
+    })
 
-    t.test('ivars', function (t) {
-      t.test('hello (utf8)', function (t) {
-        t.equal('' + m.load(ivaryHelloUtf).parsed, 'hello', 'should equal "hello"');
-        t.end();
-      });
-      t.test('hello (ascii)', function (t) {
-        t.equal('' + m.load(ivaryHelloAscii).parsed, 'hello', 'should equal "hello"');
-        t.end();
-      });
-      t.test('hello (ISO-8859-1)', function (t) {
-        t.equal('' + m.load(ivaryHelloIso8859Dash1).parsed, 'hello', 'should equal "hello"');
-        t.end();
-      });
-      t.test('lorem', function (t) {
-        t.equal('' + m.load(ivaryLorem).parsed, 'Lorem ipsum dolor sit amet, consectetur adipisicing elit. Repellat voluptas rerum eos eligendi, ducimus laborum explicabo temporibus vel ipsa exercitationem provident obcaecati eum labore expedita atque, doloremque laboriosam nisi, reprehenderit.', 'should be "Lorem ipsum ..."');
-        t.end();
-      });
-      t.end();
-    });
+    t.test('ivars', (t) => {
+      t.test('hello (utf8)', (t) => {
+        t.equal('' + m.load(ivaryHelloUtf).parsed, 'hello', 'should equal "hello"')
+        t.end()
+      })
+      t.test('hello (ascii)', (t) => {
+        t.equal('' + m.load(ivaryHelloAscii).parsed, 'hello', 'should equal "hello"')
+        t.end()
+      })
+      t.test('hello (ISO-8859-1)', (t) => {
+        t.equal('' + m.load(ivaryHelloIso8859Dash1).parsed, 'hello', 'should equal "hello"')
+        t.end()
+      })
+      t.test('lorem', (t) => {
+        t.equal(
+          '' + m.load(ivaryLorem).parsed,
+          'Lorem ipsum dolor sit amet, consectetur adipisicing elit. Repellat voluptas rerum eos eligendi, ducimus laborum explicabo temporibus vel ipsa exercitationem provident obcaecati eum labore expedita atque, doloremque laboriosam nisi, reprehenderit.',
+          'should be "Lorem ipsum ..."'
+        )
+        t.end()
+      })
+      t.end()
+    })
 
-    t.test('arrays', function (t) {
-      t.test('[]', function (t) {
-        var array = m.load(arrayyEmpty).parsed;
-        t.ok(array instanceof Array, 'should be an array instance');
-        t.equal(array.length, 0, 'should be empty');
-        t.end();
-      });
-      t.test('[1]', function (t) {
-        var array = m.load(arrayyInteger).parsed;
-        t.ok(array instanceof Array, 'should be an array instance');
-        t.equal(array.length, 1, 'should have one member');
-        t.end();
-      });
-      t.end();
-    });
+    t.test('arrays', (t) => {
+      t.test('[]', (t) => {
+        const array = m.load(arrayyEmpty).parsed
+        t.ok(array instanceof Array, 'should be an array instance')
+        t.equal(array.length, 0, 'should be empty')
+        t.end()
+      })
+      t.test('[1]', (t) => {
+        const array = m.load(arrayyInteger).parsed
+        t.ok(array instanceof Array, 'should be an array instance')
+        t.equal(array.length, 1, 'should have one member')
+        t.end()
+      })
+      t.end()
+    })
 
-    t.test('objects', function (t) {
-      t.test('empty', function (t) {
-        t.deepEqual(m.load(objectyEmpty).parsed, { _name: 'Object' }, 'should equal { _name: \'Object\' }');
-        t.end();
-      });
-      t.test('single instance variable \'@foo\'', function (t) {
-        t.deepEqual(m.load(objectyFoo).parsed, { _name: 'Object', '@foo': 'bar' }, 'should equal { _name: \'Object\', \'@foo\': \'bar\' }');
-        t.end();
-      });
-      t.test('name is link', function (t) {
+    t.test('objects', (t) => {
+      t.test('empty', (t) => {
+        t.deepEqual(m.load(objectyEmpty).parsed, { _name: 'Object' }, "should equal { _name: 'Object' }")
+        t.end()
+      })
+      t.test("single instance variable '@foo'", (t) => {
+        t.deepEqual(m.load(objectyFoo).parsed, { _name: 'Object', '@foo': 'bar' }, "should equal { _name: 'Object', '@foo': 'bar' }")
+        t.end()
+      })
+      t.test('name is link', (t) => {
         t.deepEqual(m.load(objectNameIsLink).parsed, [
-          ['s1', 's2', 's3', 's4', 's5', 's6', 's7', 's8', 's9', 's10', 's11', 's12', 's13', 's14', 's15', 's16', 's17', 's18', 's19', 's20', 's21', 's22', 's23', 's24', 's25', 's26', 's27', 's28', 's29', 's30', 's31', 's32', 's33'],
+          [ 's1', 's2', 's3', 's4', 's5', 's6', 's7', 's8', 's9', 's10', 's11', 's12', 's13', 's14', 's15', 's16', 's17', 's18', 's19', 's20', 's21', 's22', 's23', 's24', 's25', 's26', 's27', 's28', 's29', 's30', 's31', 's32', 's33' ],
           { _name: 'B' },
           { _name: 'B' }
-        ], 'should equal the test object with a name that is a symbol link and a high link index (see #6)');
-        t.end();
-      });
-      t.end();
-    });
+        ], 'should equal the test object with a name that is a symbol link and a high link index (see #6)')
+        t.end()
+      })
+      t.end()
+    })
 
-    t.test('hashes', function (t) {
-      t.test('{}', function (t) {
-        t.deepEqual(m.load(hashyEmpty).parsed, {}, 'should equal {}');
-        t.end();
-      });
-      t.test('{ 1: 2 }', function (t) {
-        t.deepEqual(m.load(hashyOneTwo).parsed, { 1: 2 }, 'should equal { 1: 2 }');
-        t.end();
-      });
-      t.end();
-    });
+    t.test('hashes', (t) => {
+      t.test('{}', (t) => {
+        t.deepEqual(m.load(hashyEmpty).parsed, {}, 'should equal {}')
+        t.end()
+      })
+      t.test('{ 1: 2 }', (t) => {
+        t.deepEqual(m.load(hashyOneTwo).parsed, { 1: 2 }, 'should equal { 1: 2 }')
+        t.end()
+      })
+      t.end()
+    })
 
-    t.test('floats', function (t) {
-      t.test('positive float', function (t) {
-        t.equal(m.load(floatyPositive).parsed, 12.3456, 'should equal 12.3456');
-        t.end();
-      });
-      t.test('negative float', function (t) {
-        t.equal(m.load(floatyNegative).parsed, -12.3456, 'should equal -12.3456');
-        t.end();
-      });
-      t.test('positive infinity', function (t) {
-        t.equal(m.load(floatyPositiveInfinity).parsed, Infinity, 'should equal Infinity');
-        t.end();
-      });
-      t.test('negative infinity', function (t) {
-        t.equal(m.load(floatyNegativeInfinity).parsed, -Infinity, 'should equal -Infinity');
-        t.end();
-      });
-      t.test('NaN', function (t) {
-        t.equal(Number.isNaN(m.load(floatyNaN).parsed), true, 'should equal NaN');
-        t.end();
-      });
-      t.end();
-    });
+    t.test('floats', (t) => {
+      t.test('positive float', (t) => {
+        t.equal(m.load(floatyPositive).parsed, 12.3456, 'should equal 12.3456')
+        t.end()
+      })
+      t.test('negative float', (t) => {
+        t.equal(m.load(floatyNegative).parsed, -12.3456, 'should equal -12.3456')
+        t.end()
+      })
+      t.test('positive infinity', (t) => {
+        t.equal(m.load(floatyPositiveInfinity).parsed, Infinity, 'should equal Infinity')
+        t.end()
+      })
+      t.test('negative infinity', (t) => {
+        t.equal(m.load(floatyNegativeInfinity).parsed, -Infinity, 'should equal -Infinity')
+        t.end()
+      })
+      t.test('NaN', (t) => {
+        t.equal(Number.isNaN(m.load(floatyNaN).parsed), true, 'should equal NaN')
+        t.end()
+      })
+      t.end()
+    })
 
-    t.end();
-  });
-  t.end();
-});
+    t.end()
+  })
+  t.end()
+})


### PR DESCRIPTION
a lot of changes, test do pass though:
- Update `package.json`
- Break: Upgrade code to ES6+, require `node@>=8`
- Format code with `prettier`
- Use `Buffer.from` instead of `new Buffer`
